### PR TITLE
feat: 일반 동영상과 쇼츠 구분 분석 기능 추가

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -1,9 +1,12 @@
+import logging
 from pathlib import Path
 
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, inspect, text
 from sqlalchemy.orm import sessionmaker, DeclarativeBase
 
 from app.config import get_settings
+
+logger = logging.getLogger(__name__)
 
 
 settings = get_settings()
@@ -21,6 +24,33 @@ SessionLocal = sessionmaker(bind=engine)
 
 class Base(DeclarativeBase):
     pass
+
+
+def migrate_db(engine_instance):
+    """기존 테이블에 새 컬럼이 없으면 추가합니다."""
+    inspector = inspect(engine_instance)
+    if "trending_videos" in inspector.get_table_names():
+        columns = {col["name"] for col in inspector.get_columns("trending_videos")}
+        with engine_instance.begin() as conn:
+            if "video_type" not in columns:
+                conn.execute(
+                    text(
+                        "ALTER TABLE trending_videos "
+                        "ADD COLUMN video_type VARCHAR(10) DEFAULT 'regular'"
+                    )
+                )
+                logger.info("Added video_type column to trending_videos")
+            if "duration_seconds" not in columns:
+                conn.execute(
+                    text(
+                        "ALTER TABLE trending_videos "
+                        "ADD COLUMN duration_seconds INTEGER"
+                    )
+                )
+                logger.info("Added duration_seconds column to trending_videos")
+
+
+migrate_db(engine)
 
 
 def get_db():

--- a/app/models.py
+++ b/app/models.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import String, func
+from sqlalchemy import Integer, String, func
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.database import Base
@@ -18,4 +18,6 @@ class TrendingVideo(Base):
     like_count: Mapped[int]
     comment_count: Mapped[int]
     published_at: Mapped[str] = mapped_column(String(30))
+    video_type: Mapped[str] = mapped_column(String(10), default="regular", index=True)
+    duration_seconds: Mapped[int | None] = mapped_column(Integer, nullable=True)
     collected_at: Mapped[datetime] = mapped_column(default=func.now(), index=True)

--- a/app/routers/categories.py
+++ b/app/routers/categories.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, Path
+from fastapi import APIRouter, Depends, Path, Query
 
 from app.config import Settings, get_settings
 from app.schemas import CategoriesResponse, PopularVideosResponse, CategoryAnalysis
@@ -47,7 +47,13 @@ def list_popular_videos(
 )
 def get_category_analysis(
     category_id: str = Path(description="카테고리 ID. 카테고리 목록 조회 API에서 확인할 수 있습니다."),
+    video_type: str | None = Query(
+        default=None,
+        description="동영상 유형 필터 (regular: 일반, shorts: 쇼츠, 미지정 시 전체)",
+    ),
     service: YouTubeService = Depends(get_youtube_service),
 ) -> CategoryAnalysis:
     videos = service.get_popular_videos_with_details(category_id)
+    if video_type:
+        videos = [v for v in videos if v.video_type == video_type]
     return analyze_category(category_id, videos)

--- a/app/routers/trends.py
+++ b/app/routers/trends.py
@@ -42,10 +42,17 @@ def collect(
 )
 def get_keyword_trends(
     days: int = Query(default=7, ge=1, le=90, description="조회 기간 (일)"),
+    video_type: str | None = Query(
+        default=None,
+        description="동영상 유형 필터 (regular: 일반, shorts: 쇼츠, 미지정 시 전체)",
+    ),
     db: Session = Depends(get_db),
 ) -> KeywordTrend:
     cutoff = datetime.now(timezone.utc) - timedelta(days=days)
-    videos = db.query(TrendingVideo).filter(TrendingVideo.collected_at >= cutoff).all()
+    query = db.query(TrendingVideo).filter(TrendingVideo.collected_at >= cutoff)
+    if video_type:
+        query = query.filter(TrendingVideo.video_type == video_type)
+    videos = query.all()
 
     # 일별 키워드 빈도 집계
     # {keyword: {date_str: count}}
@@ -84,17 +91,20 @@ def get_keyword_trends(
 def get_timeline_trends(
     category_id: str = Query(description="카테고리 ID"),
     days: int = Query(default=7, ge=1, le=90, description="조회 기간 (일)"),
+    video_type: str | None = Query(
+        default=None,
+        description="동영상 유형 필터 (regular: 일반, shorts: 쇼츠, 미지정 시 전체)",
+    ),
     db: Session = Depends(get_db),
 ) -> TimelineTrend:
     cutoff = datetime.now(timezone.utc) - timedelta(days=days)
-    videos = (
-        db.query(TrendingVideo)
-        .filter(
-            TrendingVideo.category_id == category_id,
-            TrendingVideo.collected_at >= cutoff,
-        )
-        .all()
+    query = db.query(TrendingVideo).filter(
+        TrendingVideo.category_id == category_id,
+        TrendingVideo.collected_at >= cutoff,
     )
+    if video_type:
+        query = query.filter(TrendingVideo.video_type == video_type)
+    videos = query.all()
 
     # 일별 집계
     daily_data: dict[str, list[TrendingVideo]] = defaultdict(list)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -37,6 +37,7 @@ class VideoDetail(BaseModel):
     published_at: str = Field(description="게시일시 (ISO 8601)")
     stats: VideoStats = Field(description="조회수/좋아요/댓글 통계")
     duration_seconds: int = Field(description="영상 길이 (초)")
+    video_type: str = Field(description="동영상 유형 (regular: 일반, shorts: 쇼츠)")
     tags: list[str] = Field(description="태그 목록")
     thumbnail_url: str = Field(description="썸네일 이미지 URL")
 

--- a/app/services/collector.py
+++ b/app/services/collector.py
@@ -22,7 +22,7 @@ def collect_trending_videos(
     collected_categories = 0
     for category in assignable:
         try:
-            videos = youtube_service.get_popular_videos(category.id)
+            videos = youtube_service.get_popular_videos_with_details(category.id)
         except Exception:
             logger.warning(
                 "Failed to fetch videos for category %s (%s), skipping",
@@ -45,6 +45,8 @@ def collect_trending_videos(
                 like_count=video.stats.like_count,
                 comment_count=video.stats.comment_count,
                 published_at=video.published_at,
+                video_type=video.video_type,
+                duration_seconds=video.duration_seconds,
             )
             db.add(record)
             total_videos += 1

--- a/app/services/youtube.py
+++ b/app/services/youtube.py
@@ -4,7 +4,16 @@ from googleapiclient.discovery import build
 from fastapi import HTTPException
 
 from app.config import Settings, REGION_CODE
-from app.schemas import Category, Video, VideoStats, VideoDetail
+from app.schemas import Category, Video, VideoDetail, VideoStats
+
+
+def detect_video_type(duration_seconds: int, title: str, tags: list[str]) -> str:
+    if duration_seconds <= 60:
+        return "shorts"
+    text = f"{title} {' '.join(tags)}".lower()
+    if "#shorts" in text:
+        return "shorts"
+    return "regular"
 
 
 def parse_duration(duration: str) -> int:
@@ -98,6 +107,8 @@ class YouTubeService:
         snippet = item["snippet"]
         stats = item["statistics"]
         content = item["contentDetails"]
+        duration = parse_duration(content["duration"])
+        tags = snippet.get("tags", [])
         return VideoDetail(
             id=item["id"], title=snippet["title"],
             channel_title=snippet["channelTitle"],
@@ -107,8 +118,9 @@ class YouTubeService:
                 like_count=int(stats.get("likeCount", 0)),
                 comment_count=int(stats.get("commentCount", 0)),
             ),
-            duration_seconds=parse_duration(content["duration"]),
-            tags=snippet.get("tags", []),
+            duration_seconds=duration,
+            video_type=detect_video_type(duration, snippet["title"], tags),
+            tags=tags,
             thumbnail_url=self._get_thumbnail_url(snippet.get("thumbnails", {})),
         )
 
@@ -130,6 +142,8 @@ class YouTubeService:
             snippet = item["snippet"]
             stats = item["statistics"]
             content = item["contentDetails"]
+            duration = parse_duration(content["duration"])
+            tags = snippet.get("tags", [])
             results.append(VideoDetail(
                 id=item["id"], title=snippet["title"],
                 channel_title=snippet["channelTitle"],
@@ -139,8 +153,9 @@ class YouTubeService:
                     like_count=int(stats.get("likeCount", 0)),
                     comment_count=int(stats.get("commentCount", 0)),
                 ),
-                duration_seconds=parse_duration(content["duration"]),
-                tags=snippet.get("tags", []),
+                duration_seconds=duration,
+                video_type=detect_video_type(duration, snippet["title"], tags),
+                tags=tags,
                 thumbnail_url=self._get_thumbnail_url(snippet.get("thumbnails", {})),
             ))
         return results

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -17,6 +17,7 @@ def _make_video(
     duration_seconds,
     tags=None,
     thumbnail_url="https://example.com/thumb.jpg",
+    video_type="regular",
 ):
     return VideoDetail(
         id=id,
@@ -25,6 +26,7 @@ def _make_video(
         published_at=published_at,
         stats=VideoStats(view_count=1000, like_count=50, comment_count=10),
         duration_seconds=duration_seconds,
+        video_type=video_type,
         tags=tags or [],
         thumbnail_url=thumbnail_url,
     )

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -83,12 +83,14 @@ MOCK_VIDEOS_RESPONSE = {
                 "title": "Popular Music Video",
                 "channelTitle": "Channel A",
                 "publishedAt": "2026-03-18T10:00:00Z",
+                "thumbnails": {"high": {"url": "https://example.com/vid1.jpg"}},
             },
             "statistics": {
                 "viewCount": "150000",
                 "likeCount": "3000",
                 "commentCount": "200",
             },
+            "contentDetails": {"duration": "PT5M30S"},
         },
         {
             "id": "vid2",
@@ -96,12 +98,14 @@ MOCK_VIDEOS_RESPONSE = {
                 "title": "Another Video",
                 "channelTitle": "Channel B",
                 "publishedAt": "2026-03-17T08:30:00Z",
+                "thumbnails": {"high": {"url": "https://example.com/vid2.jpg"}},
             },
             "statistics": {
                 "viewCount": "80000",
                 "likeCount": "1500",
                 "commentCount": "100",
             },
+            "contentDetails": {"duration": "PT10M"},
         },
     ]
 }
@@ -128,6 +132,8 @@ def test_collect_trending_videos():
 
     videos = db.query(TrendingVideo).all()
     assert len(videos) == 2
+    assert all(v.video_type == "regular" for v in videos)
+    assert all(v.duration_seconds is not None for v in videos)
 
 
 def test_collect_dedup_within_same_run():

--- a/tests/test_detect_video_type.py
+++ b/tests/test_detect_video_type.py
@@ -1,0 +1,31 @@
+from app.services.youtube import detect_video_type
+
+
+def test_shorts_by_duration():
+    assert detect_video_type(60, "일반 제목", []) == "shorts"
+    assert detect_video_type(30, "짧은 영상", []) == "shorts"
+    assert detect_video_type(1, "매우 짧은 영상", []) == "shorts"
+
+
+def test_regular_by_duration():
+    assert detect_video_type(61, "일반 영상", []) == "regular"
+    assert detect_video_type(300, "5분 영상", []) == "regular"
+
+
+def test_shorts_by_title_hashtag():
+    assert detect_video_type(120, "재밌는 영상 #shorts", []) == "shorts"
+    assert detect_video_type(300, "#Shorts 챌린지", []) == "shorts"
+
+
+def test_shorts_by_tag_hashtag():
+    assert detect_video_type(120, "일반 제목", ["#shorts"]) == "shorts"
+    assert detect_video_type(300, "일반 제목", ["음악", "#Shorts"]) == "shorts"
+
+
+def test_regular_without_shorts_indicator():
+    assert detect_video_type(120, "일반 동영상 제목", ["음악", "팝"]) == "regular"
+
+
+def test_shorts_hashtag_case_insensitive():
+    assert detect_video_type(120, "영상 #SHORTS", []) == "shorts"
+    assert detect_video_type(120, "영상 #ShOrTs", []) == "shorts"

--- a/tests/test_trends.py
+++ b/tests/test_trends.py
@@ -37,12 +37,14 @@ MOCK_VIDEOS_RESPONSE = {
                 "title": "인기 뮤직비디오 공식",
                 "channelTitle": "Channel A",
                 "publishedAt": "2026-03-18T10:00:00Z",
+                "thumbnails": {"high": {"url": "https://example.com/vid1.jpg"}},
             },
             "statistics": {
                 "viewCount": "150000",
                 "likeCount": "3000",
                 "commentCount": "200",
             },
+            "contentDetails": {"duration": "PT5M"},
         },
     ]
 }
@@ -164,6 +166,8 @@ def _seed_videos(db_session):
             like_count=2000,
             comment_count=100,
             published_at="2026-03-18T10:00:00Z",
+            video_type="regular",
+            duration_seconds=300,
             collected_at=today,
         ),
         TrendingVideo(
@@ -175,6 +179,8 @@ def _seed_videos(db_session):
             like_count=4000,
             comment_count=200,
             published_at="2026-03-18T10:00:00Z",
+            video_type="shorts",
+            duration_seconds=45,
             collected_at=today,
         ),
         TrendingVideo(
@@ -186,6 +192,8 @@ def _seed_videos(db_session):
             like_count=1000,
             comment_count=50,
             published_at="2026-03-17T10:00:00Z",
+            video_type="regular",
+            duration_seconds=600,
             collected_at=yesterday,
         ),
     ]
@@ -248,6 +256,27 @@ def test_get_trends_keywords_empty():
     Base.metadata.drop_all(_test_engine)
 
 
+def test_get_trends_keywords_filter_by_video_type(seeded_client):
+    response = seeded_client.get("/trends/keywords?days=7&video_type=regular")
+
+    assert response.status_code == 200
+    data = response.json()
+    # v1(regular) + v3(regular)만 포함, v2(shorts)는 제외
+    keyword_names = [k["keyword"] for k in data["keywords"]]
+    assert "뮤직비디오" in keyword_names
+
+
+def test_get_trends_keywords_filter_shorts(seeded_client):
+    response = seeded_client.get("/trends/keywords?days=7&video_type=shorts")
+
+    assert response.status_code == 200
+    data = response.json()
+    # v2(shorts)만 포함
+    keyword_names = [k["keyword"] for k in data["keywords"]]
+    assert "뮤직비디오" in keyword_names
+    assert "인기" in keyword_names
+
+
 def test_get_trends_timeline(seeded_client):
     response = seeded_client.get("/trends/timeline?category_id=10&days=7")
 
@@ -258,11 +287,22 @@ def test_get_trends_timeline(seeded_client):
     assert isinstance(data["daily_stats"], list)
     assert len(data["daily_stats"]) > 0
 
-    # 카테고리 10: 오늘 v1(100000), v2(200000) → avg=150000
+    # 카테고리 10: 오늘 v1(100000 regular), v2(200000 shorts) → avg=150000
     today_stats = data["daily_stats"][-1]
     assert today_stats["avg_view_count"] == 150000.0
     assert today_stats["avg_like_count"] == 3000.0
     assert today_stats["video_count"] == 2
+
+
+def test_get_trends_timeline_filter_by_video_type(seeded_client):
+    response = seeded_client.get("/trends/timeline?category_id=10&days=7&video_type=regular")
+
+    assert response.status_code == 200
+    data = response.json()
+    # 카테고리 10의 regular은 v1만
+    today_stats = data["daily_stats"][-1]
+    assert today_stats["video_count"] == 1
+    assert today_stats["avg_view_count"] == 100000.0
 
 
 def test_get_trends_timeline_empty_category(seeded_client):

--- a/tests/test_video_detail.py
+++ b/tests/test_video_detail.py
@@ -120,11 +120,13 @@ def test_video_detail_schema():
         published_at="2026-03-19T12:00:00Z",
         stats=VideoStats(view_count=150000, like_count=3000, comment_count=200),
         duration_seconds=933,
+        video_type="regular",
         tags=["키워드1", "키워드2"],
         thumbnail_url="https://i.ytimg.com/vi/abc123/maxresdefault.jpg",
     )
     assert detail.id == "abc123"
     assert detail.duration_seconds == 933
+    assert detail.video_type == "regular"
     assert detail.tags == ["키워드1", "키워드2"]
 
 
@@ -136,10 +138,12 @@ def test_video_detail_empty_tags():
         published_at="2026-03-19T12:00:00Z",
         stats=VideoStats(view_count=100, like_count=0, comment_count=0),
         duration_seconds=60,
+        video_type="shorts",
         tags=[],
         thumbnail_url="https://example.com/thumb.jpg",
     )
     assert detail.tags == []
+    assert detail.video_type == "shorts"
 
 
 def test_keyword_frequency_schema():
@@ -168,6 +172,14 @@ def test_category_analysis_schema():
     assert analysis.category_id == "10"
     assert analysis.video_count == 20
     assert len(analysis.keywords) == 1
+
+
+def test_get_video_detail_includes_video_type(client):
+    response = client.get("/videos/abc123/detail")
+    assert response.status_code == 200
+    data = response.json()
+    assert "video_type" in data
+    assert data["video_type"] == "regular"
 
 
 def test_get_video_details():


### PR DESCRIPTION
## Summary
- `TrendingVideo` 모델에 `video_type` (regular/shorts), `duration_seconds` 필드 추가
- `detect_video_type()` 함수로 쇼츠 판별: duration ≤ 60초 또는 제목/태그에 `#shorts` 포함
- 수집 시 `get_popular_videos_with_details` 사용하여 duration과 video_type을 DB에 저장
- 카테고리 분석, 키워드 트렌드, 타임라인 트렌드 API에 `video_type` 쿼리 파라미터 추가

## 변경 파일
- `app/models.py` — video_type, duration_seconds 컬럼 추가
- `app/schemas.py` — VideoDetail에 video_type 필드 추가
- `app/services/youtube.py` — detect_video_type 함수 추가, VideoDetail 생성 시 video_type 설정
- `app/services/collector.py` — get_popular_videos_with_details 사용, video_type/duration 저장
- `app/routers/categories.py` — 카테고리 분석 API에 video_type 필터
- `app/routers/trends.py` — 키워드/타임라인 트렌드 API에 video_type 필터

## Test plan
- [x] detect_video_type 단위 테스트 (duration, #shorts 해시태그, 대소문자)
- [x] 수집 로직 테스트 (video_type, duration_seconds 저장 확인)
- [x] 트렌드 API video_type 필터 테스트
- [x] 기존 테스트 67개 전체 통과

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)